### PR TITLE
Disable certificate check when downloading VOT database

### DIFF
--- a/create_workspace.py
+++ b/create_workspace.py
@@ -4,6 +4,8 @@ import os
 import urllib.request
 import zipfile
 from shutil import copyfile
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
 
 
 def create_workspace(workspace_path, dataset_name):


### PR DESCRIPTION
Sometimes, SSL Certificates expire and because of that you get ssl.SSLCertVerificationError and dataset is never downloaded

Because there are many enviroments this toolkit will be ran on, this change allows the dataset to be downloaded regardless of certificate validity, meaning that students will not have unnecessary problems